### PR TITLE
Data mal-form: wrong CSS-file.

### DIFF
--- a/src/Syw/Front/MainBundle/Resources/public/css/custom.css
+++ b/src/Syw/Front/MainBundle/Resources/public/css/custom.css
@@ -349,7 +349,6 @@ body {
 .form-group {
     margin-bottom: 15px;
     min-height: 23px;
-    clear: left;
 }
 
 .footercontainer {

--- a/src/Syw/Front/MainBundle/Resources/public/css/validated.css
+++ b/src/Syw/Front/MainBundle/Resources/public/css/validated.css
@@ -10482,6 +10482,7 @@ textarea.form-control {
 
 .form-group {
     margin-bottom: 15px;
+    clear: left;
 }
 
 .checkbox, .radio {


### PR DESCRIPTION
Continues the pull https://github.com/christinloehner/linuxcounter.new/pull/98.
To issues #65, #68, #71.

I see **no** changes to the forms now!

May be, the «custom.css» file – needs to be activated (by the frame-work of «Symfony-2») be-fore the usage – which will trans-form it in-to «validated.css». 

So, I re-moved the «clear: left» (of the «form-group» class): from «custom.css» – in-to the «validated.css».

